### PR TITLE
Display process output to console

### DIFF
--- a/src/main/java/io/coala/jetbrains/ui/CodeAnalysisConsoleView.java
+++ b/src/main/java/io/coala/jetbrains/ui/CodeAnalysisConsoleView.java
@@ -47,6 +47,10 @@ public class CodeAnalysisConsoleView implements ProjectComponent {
         debug(message);
         break;
 
+      case VERBOSE:
+        verbose(message);
+        break;
+
       default:
         error("Internal Plugin Error. Unidentified severity specified.");
         break;
@@ -54,18 +58,22 @@ public class CodeAnalysisConsoleView implements ProjectComponent {
   }
 
   private void info(String message) {
-    this.consoleView.print(message + "\n", ConsoleViewContentType.NORMAL_OUTPUT);
+    this.consoleView.print(message, ConsoleViewContentType.NORMAL_OUTPUT);
   }
 
   private void warn(String message) {
-    this.consoleView.print(message + "\n", ConsoleViewContentType.LOG_WARNING_OUTPUT);
+    this.consoleView.print(message, ConsoleViewContentType.LOG_WARNING_OUTPUT);
   }
 
   private void error(String message) {
-    this.consoleView.print(message + "\n", ConsoleViewContentType.ERROR_OUTPUT);
+    this.consoleView.print(message, ConsoleViewContentType.ERROR_OUTPUT);
   }
 
   private void debug(String message) {
-    this.consoleView.print(message + "\n", ConsoleViewContentType.LOG_DEBUG_OUTPUT);
+    this.consoleView.print(message, ConsoleViewContentType.LOG_DEBUG_OUTPUT);
+  }
+
+  private void verbose(String message) {
+    this.consoleView.print(message, ConsoleViewContentType.LOG_VERBOSE_OUTPUT);
   }
 }

--- a/src/main/java/io/coala/jetbrains/ui/CodeAnalysisConsoleView.java
+++ b/src/main/java/io/coala/jetbrains/ui/CodeAnalysisConsoleView.java
@@ -60,6 +60,10 @@ public class CodeAnalysisConsoleView implements ProjectComponent {
     }
   }
 
+  public void clear() {
+    this.consoleView.clear();
+  }
+
   private void info(String message) {
     this.consoleView.print(message, ConsoleViewContentType.NORMAL_OUTPUT);
   }

--- a/src/main/java/io/coala/jetbrains/ui/CodeAnalysisConsoleView.java
+++ b/src/main/java/io/coala/jetbrains/ui/CodeAnalysisConsoleView.java
@@ -4,8 +4,11 @@ import com.intellij.execution.filters.TextConsoleBuilderFactory;
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.openapi.components.ProjectComponent;
+import com.intellij.openapi.editor.markup.TextAttributes;
 import com.intellij.openapi.project.Project;
+import com.intellij.ui.JBColor;
 import io.coala.jetbrains.utils.CodeInspectionSeverity;
+import java.awt.Color;
 
 public class CodeAnalysisConsoleView implements ProjectComponent {
 
@@ -70,10 +73,19 @@ public class CodeAnalysisConsoleView implements ProjectComponent {
   }
 
   private void debug(String message) {
-    this.consoleView.print(message, ConsoleViewContentType.LOG_DEBUG_OUTPUT);
+    this.consoleView.print(message, getDebugCosoleViewContentType());
   }
 
   private void verbose(String message) {
     this.consoleView.print(message, ConsoleViewContentType.LOG_VERBOSE_OUTPUT);
+  }
+
+  private ConsoleViewContentType getDebugCosoleViewContentType() {
+    final ConsoleViewContentType errorOutput = ConsoleViewContentType.LOG_DEBUG_OUTPUT;
+    final Color color = new Color(34, 183, 52);
+
+    final TextAttributes errorOutputAttributes = errorOutput.getAttributes();
+    errorOutputAttributes.setForegroundColor(new JBColor(color, color));
+    return new ConsoleViewContentType("CONSOLE_DEBUG_OUTPUT", errorOutputAttributes);
   }
 }

--- a/src/main/java/io/coala/jetbrains/utils/CodeInspectionSeverity.java
+++ b/src/main/java/io/coala/jetbrains/utils/CodeInspectionSeverity.java
@@ -4,5 +4,6 @@ public enum CodeInspectionSeverity {
     INFO,
     WARNING,
     ERROR,
-    DEBUG
+    DEBUG,
+    VERBOSE
 }

--- a/src/test/java/io/coala/jetbrains/utils/CodeAnalysisRunnerTest.java
+++ b/src/test/java/io/coala/jetbrains/utils/CodeAnalysisRunnerTest.java
@@ -43,7 +43,7 @@ public class CodeAnalysisRunnerTest {
   public void testCommandString() {
     final String commandLineString = cmd.getCommandLineString();
     assertThat(commandLineString).isNotEmpty()
-        .isEqualTo("coala --json --filter-by section_tags jetbrains");
+        .isEqualTo("coala --json -V --filter-by section_tags jetbrains");
   }
 
   @Test

--- a/src/test/java/io/coala/jetbrains/utils/CodeAnalysisRunnerTest.java
+++ b/src/test/java/io/coala/jetbrains/utils/CodeAnalysisRunnerTest.java
@@ -8,6 +8,7 @@ import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.openapi.project.Project;
 import io.coala.jetbrains.analysis.CodeAnalysisRunner;
 import io.coala.jetbrains.settings.ProjectSettings;
+import io.coala.jetbrains.ui.CodeAnalysisConsoleView;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -20,6 +21,7 @@ public class CodeAnalysisRunnerTest {
 
   private static final Project project = mock(Project.class);
   private static final ProjectSettings projectSettings = mock(ProjectSettings.class);
+  private static final CodeAnalysisConsoleView codeAnalysisConsoleView = mock(CodeAnalysisConsoleView.class);
 
   private static final String cwd = "/path/to/file";
   private static final String executable = "coala";
@@ -33,7 +35,7 @@ public class CodeAnalysisRunnerTest {
     when(projectSettings.getExecutable()).thenReturn(executable);
     when(projectSettings.getSections()).thenReturn(sections);
 
-    final CodeAnalysisRunner codeAnalysisRunner = new CodeAnalysisRunner(project, projectSettings);
+    final CodeAnalysisRunner codeAnalysisRunner = new CodeAnalysisRunner(project, projectSettings, codeAnalysisConsoleView);
     cmd = codeAnalysisRunner.getNewGeneralCommandLine();
   }
 
@@ -41,7 +43,7 @@ public class CodeAnalysisRunnerTest {
   public void testCommandString() {
     final String commandLineString = cmd.getCommandLineString();
     assertThat(commandLineString).isNotEmpty()
-        .isEqualTo("coala --json --log-json --filter-by section_tags jetbrains");
+        .isEqualTo("coala --json --filter-by section_tags jetbrains");
   }
 
   @Test


### PR DESCRIPTION
add listener and helper methods to print process output to console

The output is shown as and when the OS gets the output ie continuously during the process execution. (And hence can also support coloring of the text as in original coala CLI)The other method was to run the process fully and then show the output all at once to the user.

Note: By the word, `output` I mean the log data Warnings/Errors/Debugs. The actual analysis data is not being talked about here.