### PR TITLE
Add tests and remove Deprecated class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version '2019.1.2'
+    version "2019.2"
 }
 patchPluginXml {
     changeNotes """

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-bin.zip

--- a/src/main/java/io/coala/jetbrains/CodeAnalysisMenu.java
+++ b/src/main/java/io/coala/jetbrains/CodeAnalysisMenu.java
@@ -1,0 +1,20 @@
+package io.coala.jetbrains;
+
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.DefaultActionGroup;
+import com.intellij.openapi.components.ApplicationComponent;
+
+public class CodeAnalysisMenu implements ApplicationComponent {
+
+  @Override
+  public void initComponent() {
+    final ActionManager actionManager = ActionManager.getInstance();
+    final DefaultActionGroup analyzeMenu = (DefaultActionGroup) actionManager
+        .getAction("AnalyzeMenu");
+    if (analyzeMenu != null) {
+      final AnAction action = actionManager.getAction("CodeAnalysis.AnalyzeMenu");
+      analyzeMenu.add(action);
+    }
+  }
+}

--- a/src/main/java/io/coala/jetbrains/utils/Notifier.java
+++ b/src/main/java/io/coala/jetbrains/utils/Notifier.java
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public final class Notifier {
-  
+
   private static final String title = "coala";
   private static final NotificationGroup NOTIFICATION = new NotificationGroup("coala",
       NotificationDisplayType.BALLOON,
@@ -56,6 +56,10 @@ public final class Notifier {
       @Override
       public void actionPerformed(@NotNull AnActionEvent anActionEvent,
           @NotNull Notification notification) {
+        if (anActionEvent.getProject() == null) {
+          return;
+        }
+
         ApplicationManager.getApplication().invokeLater(() ->
             ToolWindowManager.getInstance(anActionEvent.getProject()).getToolWindow("Event Log")
                 .show(null));

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -74,4 +74,9 @@
         <implementation-class>io.coala.jetbrains.highlight.IssueProcessor</implementation-class>
       </component>
     </project-components>
+  <application-components>
+    <component>
+      <implementation-class>io.coala.jetbrains.CodeAnalysisMenu</implementation-class>
+    </component>
+  </application-components>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -16,7 +16,7 @@
                             serviceImplementation="io.coala.jetbrains.utils.RangeMarkerTextAttributes" />
         <applicationService serviceInterface="io.coala.jetbrains.highlight.HighlightService"
                             serviceImplementation="io.coala.jetbrains.highlight.HighlightService" />
-      
+
         <toolWindow id="coala"
                     icon="/images/coala-13x13.png"
                     canCloseContents="false"
@@ -28,7 +28,6 @@
         <!-- groups -->
         <group id="CodeAnalysis.AnalyzeMenu"
                text="coala">
-            <add-to-group group-id="AnalyzeMenu" anchor="last"/>
             <separator/>
         </group>
 

--- a/src/test/java/io/coala/jetbrains/settings/ProjectSettingsTest.java
+++ b/src/test/java/io/coala/jetbrains/settings/ProjectSettingsTest.java
@@ -6,12 +6,12 @@ import com.intellij.execution.ExecutionException;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.SystemInfo;
-import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-public class ProjectSettingsTest extends LightPlatformCodeInsightFixtureTestCase {
+public class ProjectSettingsTest extends BasePlatformTestCase {
 
   private ProjectSettings projectSettings;
 
@@ -39,6 +39,22 @@ public class ProjectSettingsTest extends LightPlatformCodeInsightFixtureTestCase
 
       assertThat(projectSettingsExecutable).isNotNull()
           .isEqualTo(Paths.get("C:\\Windows\\System32\\where.exe").toAbsolutePath());
+    }
+  }
+
+  public void testAutomaticDetectionAndSettingOfExecutableIfNotExists()
+      throws InterruptedException, ExecutionException, IOException {
+    Path projectSettingsExecutable;
+
+    if (SystemInfo.isUnix) {
+      projectSettingsExecutable = projectSettings.determineAndSetExecutable("does_not_exist");
+
+      assertThat(projectSettingsExecutable).isNull();
+    }
+    if (SystemInfo.isWindows) {
+      projectSettingsExecutable = projectSettings.determineAndSetExecutable("does_not_exist");
+
+      assertThat(projectSettingsExecutable).isNull();
     }
   }
 }

--- a/src/test/java/io/coala/jetbrains/utils/NotifierTest.java
+++ b/src/test/java/io/coala/jetbrains/utils/NotifierTest.java
@@ -1,0 +1,23 @@
+package io.coala.jetbrains.utils;
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+public class NotifierTest extends BasePlatformTestCase {
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+  }
+
+  public void testShowInformationNotification() {
+    Notifier.showInformationNotification("Information");
+  }
+
+  public void testShowWarningNotification() {
+    Notifier.showWarningNotification("Warning");
+  }
+
+  public void testShowErrorNotification() {
+    Notifier.showErrorNotification("Random exception", new Exception("Random exception"));
+  }
+}


### PR DESCRIPTION
Notifier tests

Move to the new `BasePlatformTestCase` as `LightPlatformCodeInsightFixtureTestCase` is deprecated in IntelliJ 192.x