### PR TITLE
Add coala menu group to analyze menu programmatically

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version '2019.1.2'
+    version "2019.2"
 }
 patchPluginXml {
     changeNotes """

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-bin.zip

--- a/src/main/java/io/coala/jetbrains/CodeAnalysisMenu.java
+++ b/src/main/java/io/coala/jetbrains/CodeAnalysisMenu.java
@@ -1,0 +1,20 @@
+package io.coala.jetbrains;
+
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.DefaultActionGroup;
+import com.intellij.openapi.components.ApplicationComponent;
+
+public class CodeAnalysisMenu implements ApplicationComponent {
+
+  @Override
+  public void initComponent() {
+    final ActionManager actionManager = ActionManager.getInstance();
+    final DefaultActionGroup analyzeMenu = (DefaultActionGroup) actionManager
+        .getAction("AnalyzeMenu");
+    if (analyzeMenu != null) {
+      final AnAction action = actionManager.getAction("CodeAnalysis.AnalyzeMenu");
+      analyzeMenu.add(action);
+    }
+  }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -74,4 +74,9 @@
         <implementation-class>io.coala.jetbrains.highlight.IssueProcessor</implementation-class>
       </component>
     </project-components>
+  <application-components>
+    <component>
+      <implementation-class>io.coala.jetbrains.CodeAnalysisMenu</implementation-class>
+    </component>
+  </application-components>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -16,7 +16,7 @@
                             serviceImplementation="io.coala.jetbrains.utils.RangeMarkerTextAttributes" />
         <applicationService serviceInterface="io.coala.jetbrains.highlight.HighlightService"
                             serviceImplementation="io.coala.jetbrains.highlight.HighlightService" />
-      
+
         <toolWindow id="coala"
                     icon="/images/coala-13x13.png"
                     canCloseContents="false"
@@ -28,7 +28,6 @@
         <!-- groups -->
         <group id="CodeAnalysis.AnalyzeMenu"
                text="coala">
-            <add-to-group group-id="AnalyzeMenu" anchor="last"/>
             <separator/>
         </group>
 


### PR DESCRIPTION
adds coala menu group to analyze menu programmatically since some flavors of IntelliJ do not have this menu. (hence was failing due to platform update)

Closes #34 

Rebased on top of #33 